### PR TITLE
nodejs v0.4.8 doesn't have pair._ssl anymore

### DIFF
--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -15,7 +15,8 @@ function starttls(socket, opt, next) {
       cleartext = pipe(pair, socket);
 
   pair.on('secure', function() {
-    var error = pair._ssl.verifyError();
+    var ssl = pair._ssl || pair.ssl;
+    var error = ssl.verifyError();
 
     if (error) {
       cleartext.authorized = false;


### PR DESCRIPTION
nodejs v0.4.8 doesn't have pair._ssl anymore. Changed behavior with backwards support as well.
