### PR TITLE
variable 'domain' name conflict resolved

### DIFF
--- a/lib/smtp.js
+++ b/lib/smtp.js
@@ -33,7 +33,7 @@ function Client(opt) {
   }
 
   this.port = opt.port || (this.useTLS ? 587 : 25);
-  this.domain = opt.domain;
+  this.domainName = opt.domain;
   if (opt.username)
     this.setLogin(opt.username, opt.password);
 
@@ -44,7 +44,7 @@ function Client(opt) {
 Client.prototype.mail = function(from, to) {
   var self = this;
 
-  this.domain = this.domain || OS.hostname();
+  this.domainName = this.domainName || OS.hostname();
 
   process.nextTick(function() {
     self.connect();
@@ -57,8 +57,8 @@ Client.prototype.mail = function(from, to) {
 Client.prototype.connect = function() {
   var self = this;
 
-  if (!this.domain)
-    this.emit('error', new Error('Missing required domain.'));
+  if (!this.domainName)
+    this.emit('error', new Error('Missing required domainName.'));
   else if (this.sock.readyState != 'closed')
     this.emit('error', new Error('Session already started.'));
   else {
@@ -184,7 +184,7 @@ Client.prototype.command = function(name, args, callback) {
 Client.prototype.hello = function(ready) {
   var self = this;
 
-  self.command('ehlo', self.domain, function() {
+  self.command('ehlo', self.domainName, function() {
     U.aEach(arguments, extend, ready);
   });
 


### PR DESCRIPTION
EventEmitter has variable named 'domain'.
So, 'domain' in smtp.js is convert to 'domainName'
